### PR TITLE
영상 촬영이 시작되지 않았을 경우에 면접 시작 버튼을 누르면 alert(“화면에 카메라 영상이 나타나면 시작이 가능합니다.) 띄우기

### DIFF
--- a/src/models/simulation/video.ts
+++ b/src/models/simulation/video.ts
@@ -21,7 +21,7 @@ export const useVideoHandler = (videoRef: React.RefObject<HTMLVideoElement>) => 
         videoRef.current.srcObject = mediaStream;
       }
     } catch (err) {
-      alert('video 연결에 실패했습니다.');
+      alert('카메라 정보를 가져오지 못했습니다. 권한 설정을 확인해주세요.');
     }
   }, [videoRef, setStream]);
 
@@ -61,7 +61,7 @@ export const useVideoHandler = (videoRef: React.RefObject<HTMLVideoElement>) => 
       mediaRecorderRef.current.start();
       setRecording(true);
     } catch (err) {
-      alert('화면 녹화 시작에 실패했습니다.');
+      alert('화면에 카메라가 켜질 때까지 기다려주세요.');
     }
   };
   const handleStopRecording = () => {


### PR DESCRIPTION
## 어떤 기능인가요?

영상 촬영이 시작되지 않았을 경우에 면접 시작 버튼을 누르면 alert(“화면에 카메라 영상이 나타나면 시작이 가능합니다.) 띄우기



## 작업 상세 내용

- [ ] alert 내용 변경

> 리뷰어가 어떻게 볼 수 있나요?

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

> 리뷰어가 확인할 수 있는 캡처가 있다면 추가해 주세요.

## 고민되거나 어려운 부분 (선택)

> 이거 중점으로 봐주세요 👀
