### PR TITLE
style: 홈(/)페이지의 스타일 수정

### DIFF
--- a/src/app/(home)/page.module.scss
+++ b/src/app/(home)/page.module.scss
@@ -1,81 +1,87 @@
-.main {
+.container {
   width: calc(100vw);
   height: 100vh;
   background: linear-gradient(150deg, #004922 0%, #02632f 40%, #058841 70%, #fff 70%);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0px 80px;
+  gap: 120px;
+  padding: 0px 120px;
 }
 
-.left {
-  width: 610px;
-
+.introduceContainer {
+  width: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
-  gap: 31px;
+  justify-content: center;
+
+  .introduce {
+    width: 690px;
+    display: flex;
+    flex-direction: column;
+    align-items: baseline;
+    gap: 40px;
+  }
 }
 
 .heading {
   color: #fff;
-  text-align: center;
-  font-size: 36px;
+  font-size: 52px;
   font-weight: 700;
   line-height: 1.3;
 
   & span {
     color: #fff9c1;
-    font-size: 36px;
+    font-size: 60px;
     font-weight: 700;
   }
 }
 
 .description {
   color: #fff;
-  text-align: center;
   font-size: 20px;
   font-weight: 300;
   line-height: 1.3;
   word-break: keep-all;
 }
 
-.interviewBtn {
-  margin-top: 56px;
-  padding: 12px 77px;
-  border-radius: 42.5px;
-  background: #fff9c1;
-  border: none;
+.interviewBtnWrapper {
+  margin-top: 8px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
-  color: #025729;
-  font-size: 24px;
-  font-weight: 700;
-  text-decoration: none;
+  .interviewBtn {
+    padding: 18px 84px;
+    border-radius: 42.5px;
+    background: #fff9c1;
+    border: none;
+    color: #025729;
+    font-size: 34px;
+    font-weight: 700;
+    text-decoration: none;
+
+    &:hover {
+      background: #d3ce9f;
+      transition: background-color 0.1s ease-in-out;
+    }
+  }
 }
 
-.gettyImage {
-  background: url('../../../public/gettyImage.png');
-  width: 823px;
-  height: 549px;
+.gettyImageWrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
 }
 
 @media (max-width: 1280px) and (min-width: 650px) {
-  .main {
+  .container {
     justify-content: center;
   }
 
-  .layout {
-    padding: 0px 20px;
-  }
-
-  .gettyImage {
-    display: none;
-  }
-}
-
-@media (max-width: 650px) {
-  .gettyImage {
+  .gettyImageWrapper {
     display: none;
   }
 }

--- a/src/app/(home)/page.module.scss
+++ b/src/app/(home)/page.module.scss
@@ -1,6 +1,6 @@
 .main {
   width: calc(100vw);
-  height: calc(100vh - 63px);
+  height: 100vh;
   background: linear-gradient(150deg, #004922 0%, #02632f 40%, #058841 70%, #fff 70%);
   display: flex;
   justify-content: space-between;

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,22 +1,29 @@
-import styles from './page.module.scss';
 import Link from 'next/link';
+import Image from 'next/image';
+import styles from './page.module.scss';
 
 export default function Home() {
   return (
-    <main className={styles.main}>
-      <div className={styles.left}>
-        <p className={styles.heading}>
-          연습을 통해 면접을 대비해보세요.
-          <br /> <span>“떨면 뭐하니”</span>가 도와드립니다.
-        </p>
-        <p className={styles.description}>
-          떨면뭐하니의 모의 면접을 이용하여 당신의 꿈을 이뤄줄 면접을 대비해보세요.
-        </p>
-        <Link href="/interview" className={styles.interviewBtn}>
-          모의면접
-        </Link>
-      </div>
-      <div className={styles.gettyImage}></div>
-    </main>
+    <div className={styles.container}>
+      <section className={styles.introduceContainer}>
+        <div className={styles.introduce}>
+          <p className={styles.heading}>
+            연습을 통해 면접을 대비해보세요.
+            <br /> <span>떨면 뭐하니</span>가 도와드립니다.
+          </p>
+          <p className={styles.description}>
+            떨면뭐하니의 모의 면접을 이용하여 당신의 꿈을 이뤄줄 면접을 대비해보세요.
+          </p>
+          <div className={styles.interviewBtnWrapper}>
+            <Link href="/interview" className={styles.interviewBtn}>
+              모의면접
+            </Link>
+          </div>
+        </div>
+      </section>
+      <section className={styles.gettyImageWrapper}>
+        <Image src="/gettyImage.png" width={720} height={480} alt="character-image" />
+      </section>
+    </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,3 +132,7 @@ table {
   box-sizing: border-box;
   text-decoration: none;
 }
+
+body {
+  position: relative;
+}

--- a/src/app/interview/page.module.scss
+++ b/src/app/interview/page.module.scss
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  height: calc(100vh - 63px);
+  height: 100vh;
   background: linear-gradient(150deg, #004922 0%, #02632f 40%, #058841 70%);
   min-width: 660px;
   width: 100%;

--- a/src/components/user/LogOutBtn/LogOutBtn.module.scss
+++ b/src/components/user/LogOutBtn/LogOutBtn.module.scss
@@ -2,10 +2,12 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 4px 8px;
-  font-size: 16px;
-  background-color: red;
-  border-radius: 8px;
-  color: white;
+  background-color: #ffffff;
+  font-size: 20px;
+  cursor: pointer;
   border: none;
+}
+
+.logout_btn:hover {
+  color: rgba($color: #000000, $alpha: 0.7);
 }

--- a/src/components/user/LogOutBtn/LogOutBtn.module.scss
+++ b/src/components/user/LogOutBtn/LogOutBtn.module.scss
@@ -2,12 +2,13 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: #ffffff;
-  font-size: 20px;
+  background-color: transparent;
+  font-size: 24px;
   cursor: pointer;
   border: none;
+  color: #ffffff;
 }
 
 .logout_btn:hover {
-  color: rgba($color: #000000, $alpha: 0.7);
+  color: rgba($color: #ffffff, $alpha: 0.7);
 }

--- a/src/components/user/LogOutBtn/index.tsx
+++ b/src/components/user/LogOutBtn/index.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { removeCookie } from '@/shared/utils/cookies';
+import { MdLogout } from 'react-icons/md';
 import styles from './LogOutBtn.module.scss';
 
 export const LogOutBtn = () => {
@@ -14,7 +15,7 @@ export const LogOutBtn = () => {
   };
   return (
     <button type="submit" className={styles.logout_btn} onClick={handleLogout}>
-      로그아웃
+      <MdLogout />
     </button>
   );
 };

--- a/src/components/user/UserProfile/UserProfile.module.scss
+++ b/src/components/user/UserProfile/UserProfile.module.scss
@@ -1,11 +1,11 @@
 .container {
   display: flex;
   justify-content: center;
-  gap: 10px;
+  align-items: center;
 }
 
 .profile_img {
-  border-radius: 50%;
+  border-radius: 100%;
 }
 
 .hamburger {

--- a/src/components/user/UserProfile/index.tsx
+++ b/src/components/user/UserProfile/index.tsx
@@ -8,7 +8,7 @@ interface Props {
 export const UserProfile = ({ profileImg }: Props) => {
   return (
     <div className={styles.container}>
-      <Image src={profileImg} className={styles.profile_img} width={32} height={32} alt="profile" />
+      <Image src={profileImg} className={styles.profile_img} width={40} height={40} alt="profile" />
     </div>
   );
 };

--- a/src/shared/utils/protectRoute.ts
+++ b/src/shared/utils/protectRoute.ts
@@ -6,7 +6,7 @@ export function protectRoute({ req, route }: { req: NextRequest; route: string }
   if (pathname.startsWith(`/${route}`)) {
     const accessToken = req.cookies.get('accessToken');
 
-    if (!accessToken) {
+    if (!accessToken || accessToken.toString().length < 1) {
       return NextResponse.redirect(new URL('/signin', req.url));
     }
   }

--- a/src/widgets/Header/Header.module.scss
+++ b/src/widgets/Header/Header.module.scss
@@ -1,9 +1,8 @@
 .layout {
-  min-width: 661px;
-  padding: 0px 80px;
+  position: absolute;
+  top: 0;
   display: flex;
   justify-content: space-between;
-  background: #fff;
   align-items: center;
   width: 100%;
 }

--- a/src/widgets/Header/Header.module.scss
+++ b/src/widgets/Header/Header.module.scss
@@ -5,6 +5,7 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
+  padding: 20px;
 }
 
 .nav {
@@ -21,8 +22,8 @@
   margin-right: 20px;
 
   p {
-    color: #000;
-    font-size: 24px;
+    color: #ffffff;
+    font-size: 28px;
     font-weight: 800;
   }
 }
@@ -40,20 +41,10 @@
 }
 
 .profile_img {
-  border-radius: 50%;
-}
-
-@media (max-width: 1280px) and (min-width: 781px) {
-  .layout {
-    padding: 0px 20px;
-  }
+  border-radius: 100%;
 }
 
 @media (max-width: 780px) {
-  .layout {
-    padding: 0px 20px;
-  }
-
   .logo p {
     display: none;
   }


### PR DESCRIPTION
- 헤더의 포지션을 absolute로 변경하고 투명색상을 주어 화면 상단에 고정하게끔 하였습니다.
- 배경색으로 인해 로고 텍스트 색상과 로그아웃 버튼의 색상을 #ffffff로 변경했습니다.
- 기존에 background로 들어갔던 이미지를 next/Image로 변경하고 크기를 조정해주었습니다.
- 소개 문구의 정렬을 왼쪽으로 두었고 모의면접 버튼의 크기를 더 크게 해주었습니다.

- 결과물 스크린샷입니다.
![홈스타일수정스샷](https://github.com/user-attachments/assets/4dd5b14e-d85c-4aaf-af44-aacdab34d443)
