### PR TITLE
feat: interview page의 ready step에 마이크 테스트 UI와 기능 추가

### DIFF
--- a/src/models/audio/useSTT.ts
+++ b/src/models/audio/useSTT.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
 
 /**
@@ -15,7 +15,8 @@ import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognitio
 */
 export const useSTT = () => {
   const text = useRef<string>();
-  const { transcript, resetTranscript } = useSpeechRecognition();
+  const [isListen, setIsListen] = useState(false);
+  const { transcript, listening, resetTranscript } = useSpeechRecognition();
 
   /**
    * 녹음을 시작하고 한국어로 음성을 인식합니다.
@@ -23,6 +24,7 @@ export const useSTT = () => {
    * @returns {void}
    */
   const handleRecAudio = () => {
+    setIsListen(true);
     text.current = '';
     SpeechRecognition.startListening({ continuous: true, language: 'ko' });
   };
@@ -32,6 +34,7 @@ export const useSTT = () => {
    * 또한, 다음 녹음을 위해 인식된 텍스트를 초기화합니다.
    */
   const handleStopRecAudio = () => {
+    setIsListen(false);
     SpeechRecognition.abortListening();
     text.current = transcript;
     resetTranscript();
@@ -39,6 +42,7 @@ export const useSTT = () => {
 
   return {
     text,
+    isListen,
     handleRecAudio,
     handleStopRecAudio,
   };

--- a/src/widgets/interview/Ready/Ready.module.scss
+++ b/src/widgets/interview/Ready/Ready.module.scss
@@ -8,6 +8,7 @@
 
 .content_layout {
   display: flex;
+  gap: 50px;
   justify-content: space-between;
 
   .description {
@@ -34,6 +35,18 @@
     flex: 1;
     width: 100%;
     height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
+    .recording {
+      border-radius: 8px;
+      padding: 8px 16px;
+      border: 1px solid #000;
+      background-color: #058841;
+      color: #fff;
+      cursor: pointer;
+    }
 
     video {
       width: 100%;
@@ -43,6 +56,15 @@
       object-fit: fill;
     }
   }
+}
+
+.stt_text_container {
+  width: 100%;
+  height: 100%;
+  border: 1px solid #000;
+  margin-top: 24px;
+  border-radius: 4px;
+  padding: 8px 12px;
 }
 
 .btn_container {

--- a/src/widgets/interview/Ready/index.tsx
+++ b/src/widgets/interview/Ready/index.tsx
@@ -1,9 +1,10 @@
 import 'regenerator-runtime/runtime';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 import Button from '@/shared/components/Button/Button';
 import styles from './Ready.module.scss';
 import { useVideoHandler } from '@/models/simulation/video';
+import { useSTT } from '@/models/audio/useSTT';
 
 interface Props {
   onChangeStatus: (status: 'stacks' | 'ready' | 'start' | 'end') => void;
@@ -12,6 +13,12 @@ interface Props {
 export const Ready = ({ onChangeStatus }: Props) => {
   const videoRef = useRef(null);
   useVideoHandler(videoRef);
+
+  const { text, isListen, handleRecAudio, handleStopRecAudio } = useSTT();
+
+  const handleAudio = () => {
+    return isListen ? handleStopRecAudio() : handleRecAudio();
+  };
 
   return (
     <div className={styles.layout}>
@@ -22,10 +29,14 @@ export const Ready = ({ onChangeStatus }: Props) => {
             <p>1. 마이크를 충분히 가까이 하신 후 시작해주세요. </p>
             <p>2. 발음이 불분명하거나 빠르게 말할 경우 인식이 어려울 수 있습니다.</p>
             <p>3. 답을 완전히 말씀하신 후 1초 정도 뒤에 버튼을 눌러주세요.</p>
+            <div className={styles.stt_text_container}>{text.current}</div>
           </div>
         </div>
         <div className={styles.video_wrap}>
           <video ref={videoRef} autoPlay muted />
+          <button className={styles.recording} onClick={handleAudio}>
+            {isListen ? '녹음 중지!' : '녹음을 테스트 해보세요!'}
+          </button>
         </div>
       </div>
       <div className={styles.btn_container}>


### PR DESCRIPTION
## 어떤 기능인가요?

interview page의 ready step에 마이크 테스트 UI와 기능 추가

## 작업 상세 내용

- [x] 마이크 테스트 버튼 추가
- [x] 마이크 테스트 결과 text UI 추가
- [x] useSTT 기능과 화면 연결

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

<img width="1423" alt="스크린샷 2024-10-15 오후 5 19 19" src="https://github.com/user-attachments/assets/86e9110f-2b29-4760-9fcc-b85fbbd0e7db">


