### PR TITLE
fix: interview 페이지의 stacks 선택 창에서 아무것도 선택하지 않아도 넘어가는 현상 수정

### DIFF
--- a/src/widgets/interview/Stacks/index.tsx
+++ b/src/widgets/interview/Stacks/index.tsx
@@ -44,6 +44,9 @@ export const Stacks = ({ onChangeStatus, stacks }: Props) => {
   };
 
   const applySelectedStacks = () => {
+    if (!selectedStacks.length) {
+      return;
+    }
     const queryString = createQueryString('stacks', selectedStacks.join(','));
     router.push(`${pathname}?${queryString}`);
     onChangeStatus('ready');


### PR DESCRIPTION
## 어떤 기능인가요?
- interview 페이지의 stacks 선택 창에서 아무것도 선택하지 않아도 넘어가는 현상 수정

## 작업 상세 내용

- [x] applySelectedStacks 함수에 다음과 같은 코드 추가
 ```
if (!selectedStacks.length) {
      return;
    }
```