### PR TITLE
style: Header 컴포넌트 style 수정 및 profileImg에 드롭다운 메뉴 추가

### DIFF
--- a/src/components/user/UserProfile/UserProfile.module.scss
+++ b/src/components/user/UserProfile/UserProfile.module.scss
@@ -12,3 +12,21 @@
   border: none;
   background-color: transparent;
 }
+
+.chakra_menu__menu_button {
+  background: none !important;
+  border: none !important;
+}
+
+.chakra_menu__menu_list {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 5px !important;
+  min-width: 100% !important;
+  padding: 5px !important;
+}
+
+.chakra_menu_menu_item {
+  font-size: 15px;
+  font-weight: 600;
+}

--- a/src/components/user/UserProfile/index.tsx
+++ b/src/components/user/UserProfile/index.tsx
@@ -1,14 +1,59 @@
+'use client';
+
+import { IconButton, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
 import styles from './UserProfile.module.scss';
 import Image from 'next/image';
+import { MdLogout } from 'react-icons/md';
+import { removeCookie } from '@/shared/utils/cookies';
+import { useRouter } from 'next/navigation';
 
 interface Props {
   profileImg: string;
 }
 
+export const UserProfileHamburger = ({ profileImg }: Props) => {
+  const router = useRouter();
+
+  const handleLogout = () => {
+    removeCookie('profileImg', '/');
+    removeCookie('accessToken', '/');
+    router.refresh();
+  };
+
+  return (
+    <div className={styles.profile}>
+      <Menu>
+        <MenuButton
+          className={styles.chakra_menu__menu_button}
+          as={IconButton}
+          icon={<UserProfile profileImg={profileImg} />}
+          variant="outline"
+        />
+        <MenuList className={styles.chakra_menu__menu_list}>
+          <MenuItem
+            className={styles.chakra_menu_menu_item}
+            icon={<MdLogout size={20} />}
+            onClick={handleLogout}
+          >
+            로그아웃
+          </MenuItem>
+        </MenuList>
+      </Menu>
+    </div>
+  );
+};
+
 export const UserProfile = ({ profileImg }: Props) => {
   return (
     <div className={styles.container}>
-      <Image src={profileImg} className={styles.profile_img} width={40} height={40} alt="profile" />
+      <Image
+        src={profileImg}
+        className={styles.profile_img}
+        width={50}
+        height={50}
+        alt="profile"
+        objectFit="fill"
+      />
     </div>
   );
 };

--- a/src/widgets/Header/Header.module.scss
+++ b/src/widgets/Header/Header.module.scss
@@ -5,7 +5,7 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  padding: 20px;
+  padding: 20px 40px 0px 20px;
 }
 
 .nav {

--- a/src/widgets/Header/Header.tsx
+++ b/src/widgets/Header/Header.tsx
@@ -1,8 +1,8 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { cookies } from 'next/headers';
-import { LogInBtn, LogOutBtn, UserProfile } from '@/components/user';
 import styles from './Header.module.scss';
+import { cookies } from 'next/headers';
+import { UserProfileHamburger } from '@/components/user/UserProfile';
 
 const Header = () => {
   const cookieStore = cookies();
@@ -18,9 +18,7 @@ const Header = () => {
             <p>떨면뭐하니</p>
           </div>
         </Link>
-        <div className={styles.profile}>
-          {profileImg && accessToken && <UserProfile profileImg={profileImg} />}
-        </div>
+        {profileImg && accessToken && <UserProfileHamburger profileImg={profileImg} />}
       </nav>
     </header>
   );

--- a/src/widgets/Header/Header.tsx
+++ b/src/widgets/Header/Header.tsx
@@ -19,8 +19,7 @@ const Header = () => {
           </div>
         </Link>
         <div className={styles.profile}>
-          {profileImg && <UserProfile profileImg={profileImg} />}
-          {accessToken ? <LogOutBtn /> : <LogInBtn />}
+          {profileImg && accessToken && <UserProfile profileImg={profileImg} />}
         </div>
       </nav>
     </header>


### PR DESCRIPTION
## 어떤 기능인가요?

Header 컴포넌트 style 수정 및 profileImg에 드롭다운 메뉴 추가

## 작업 상세 내용

- [x] userProfile에 로그아웃 기능이 있는 드롭다운 메뉴 추가
- [x] header에 리뉴얼한 userProfile 적용
- [x] header에 존재하던 Login button과 Logout button 삭제
- [x] header의 layout padding을 변경하여 profileImg 컴포넌트의 위치를 기존의 위치보다 좌측으로 이동


## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

![스크린샷 2024-10-18 오후 9 56 03](https://github.com/user-attachments/assets/571dc9de-b319-42bc-93d3-7543714e83d2)

![스크린샷 2024-10-18 오후 9 56 49](https://github.com/user-attachments/assets/1d0a8f02-8f9c-4570-8280-0de20c3cfb70)

![스크린샷 2024-10-18 오후 9 57 18](https://github.com/user-attachments/assets/a97786e6-de7c-408d-815e-7eddc1cb2b96)