### PR TITLE
style: PrimaryBtn과 stack 선택 버튼 UI 변경

### DIFF
--- a/src/shared/components/Button/PrimaryBtn/PrimaryBtn.module.scss
+++ b/src/shared/components/Button/PrimaryBtn/PrimaryBtn.module.scss
@@ -13,6 +13,7 @@
 
   &:hover {
     background-color: #058841;
+    color: #fff;
     transition: background-color 0.2s ease-in-out;
   }
 

--- a/src/widgets/interview/Stacks/Stacks.module.scss
+++ b/src/widgets/interview/Stacks/Stacks.module.scss
@@ -27,13 +27,14 @@
   padding: 8px 20px;
   border-radius: 80px;
   background-color: #ffffff;
-  box-shadow: 0 0 4px 2px rgba($color: #000000, $alpha: 0.2);
-  border: 0.5px solid transparent;
+  box-shadow: 0 0 4px 3px rgba($color: #000000, $alpha: 0.2);
+  border: 0.5px solid #058841;
   cursor: pointer;
 }
 
 .stack_name_btn:hover {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: #058841;
+  color: #fff;
   transition: background-color 0.2s ease-in-out;
 }
 
@@ -41,9 +42,10 @@
   font-size: 36px;
   padding: 8px 20px;
   border-radius: 80px;
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: #058841;
   transition: background-color 0.2s ease-in-out;
   border: 0.5px solid rgba(0, 0, 0, 0.1);
+  color: #fff;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## 어떤 기능인가요?

PrimaryBtn과 stack 선택 버튼 UI 변경

## 작업 상세 내용

PrimaryBtn UI 변경내역
- [x] PrimaryBtn을 hover 했을 경우 color를 #fff로 변경

stack 선택 버튼 UI 변경내역
- [x] box-shadow의 두께를 2px --> 3px로 변경
- [x] hover 했을 경우 bg-color를 #058841로 변경
- [x] hover 했을 경우 color를 #fff로 변경
- [x] 선택됐을 경우 bg-color를 #058841로 변경
- [x] 선택됐을 경우 color를 #fff로 변경


## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

<img width="385" alt="스크린샷 2024-10-18 오후 11 29 47" src="https://github.com/user-attachments/assets/85f91369-135d-46a3-b613-0a3db089420f">


<img width="1436" alt="스크린샷 2024-10-18 오후 11 29 27" src="https://github.com/user-attachments/assets/3ef5ad43-572d-45a8-8e22-c10a04084bb9">
