### PR TITLE
interview/ready의 STT box UI 변경 및 내용물 넘치지 않도록 하는 함수 추가

### DIFF
--- a/src/widgets/interview/Ready/Ready.module.scss
+++ b/src/widgets/interview/Ready/Ready.module.scss
@@ -16,6 +16,7 @@
     display: flex;
     flex-direction: column;
     gap: 20px;
+    height: 100%;
 
     h1 {
       font-size: 36px;
@@ -27,6 +28,8 @@
       display: flex;
       flex-direction: column;
       gap: 8px;
+      width: 100%;
+      height: 100%;
       font-size: 20px;
     }
   }
@@ -65,6 +68,8 @@
   margin-top: 24px;
   border-radius: 4px;
   padding: 8px 12px;
+  display: flex;
+  align-items: center;
 }
 
 .btn_container {

--- a/src/widgets/interview/Ready/index.tsx
+++ b/src/widgets/interview/Ready/index.tsx
@@ -20,6 +20,14 @@ export const Ready = ({ onChangeStatus }: Props) => {
     return isListen ? handleStopRecAudio() : handleRecAudio();
   };
 
+  const sliceTranscript = (transcript: string) => {
+    if (transcript.length > 15) {
+      return `${transcript.slice(0, 15)}...`;
+    } else {
+      return transcript;
+    }
+  };
+
   return (
     <div className={styles.layout}>
       <div className={styles.content_layout}>
@@ -29,7 +37,9 @@ export const Ready = ({ onChangeStatus }: Props) => {
             <p>1. 마이크를 충분히 가까이 하신 후 시작해주세요. </p>
             <p>2. 발음이 불분명하거나 빠르게 말할 경우 인식이 어려울 수 있습니다.</p>
             <p>3. 답을 완전히 말씀하신 후 1초 정도 뒤에 버튼을 눌러주세요.</p>
-            <div className={styles.stt_text_container}>{text.current}</div>
+            <div className={styles.stt_text_container}>
+              {text.current ? sliceTranscript(text.current) : '녹음된 음성이 Text로 표시됩니다!'}
+            </div>
           </div>
         </div>
         <div className={styles.video_wrap}>


### PR DESCRIPTION
## 어떤 기능인가요?

interview/ready의 STT box UI 변경 및 내용물 넘치지 않도록 하는 함수 추가

## 작업 상세 내용

- [x] transcript가 15가 넘어가면 ...으로 처리하는 함수 추가
- [x] content layout의 크기에 높이가 맞도록 설정


## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

<img width="1435" alt="스크린샷 2024-10-18 오후 11 57 58" src="https://github.com/user-attachments/assets/3fb0bb06-8cdf-48f3-84df-aea112aa7004">

<img width="1438" alt="스크린샷 2024-10-18 오후 11 58 27" src="https://github.com/user-attachments/assets/525f240a-3762-42fc-9a69-3b7507ca8a2f">