### PR TITLE
style: Chat message Container style 수정

### DIFF
--- a/src/components/chat/chatting/Chatting.module.scss
+++ b/src/components/chat/chatting/Chatting.module.scss
@@ -29,7 +29,8 @@
   align-items: flex-end;
   background-color: #f5f5f5;
   border-radius: 8px;
-  padding: 4px 8px;
+  padding: 8px 12px;
+  line-height: 1.3;
   word-break: break-all;
   color: #6f6f6f;
   max-width: 60%;
@@ -41,7 +42,8 @@
   background: #17ce91;
   color: #fff;
   border-radius: 8px;
-  padding: 4px 8px;
+  padding: 8px 12px;
+  line-height: 1.3;
   word-break: break-all;
   max-width: 60%;
 }


### PR DESCRIPTION
## 어떤 기능인가요?

가독성을 위해서 Chat message Container style을 수정했습니다.

## 작업 상세 내용

- [x] padding 증가
- [x] line-height: 1.3; 적용


## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

<img width="332" alt="스크린샷 2024-10-19 오전 11 39 42" src="https://github.com/user-attachments/assets/e17d9770-e346-425e-ad29-635581767716">