### PR TITLE
style: Chat에서 scrollbar style 제거

### DIFF
--- a/src/widgets/chat/Chat.module.scss
+++ b/src/widgets/chat/Chat.module.scss
@@ -14,6 +14,12 @@
   flex-direction: column;
   gap: 12px;
   overflow-y: auto;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .other {


### PR DESCRIPTION
## 어떤 기능인가요?

UI 디자인을 위해서 scrollbar style 제거

## 작업 상세 내용

- [x] Chat UI에서 scollbar style 제거 (적용 browser: firefox, Edge, chrome)


## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

<img width="327" alt="스크린샷 2024-10-19 오전 11 52 32" src="https://github.com/user-attachments/assets/dfe6d675-1599-4c3b-99bf-5083adb9205a">
