### PR TITLE
style: chat name을 단순 이름에서 profileImg와 이름으로 변경

### DIFF
--- a/src/component_list/chattingList/ChattingList.tsx
+++ b/src/component_list/chattingList/ChattingList.tsx
@@ -6,6 +6,7 @@ interface Props {
     type: 'other' | 'mine' | 'recording' | 'exit';
     name: string;
     message: string;
+    profileImg: string;
   }[];
   recordingBox: boolean;
   onRecAudio: () => void;
@@ -28,6 +29,7 @@ const ChattingList = ({
         type={chatInfo.type}
         name={chatInfo.name}
         message={chatInfo.message}
+        profileImg={chatInfo.profileImg}
         questionIsLoading
         recordingBox={recordingBox}
         onRecAudio={onRecAudio}

--- a/src/components/chat/chatting/Chatting.module.scss
+++ b/src/components/chat/chatting/Chatting.module.scss
@@ -10,18 +10,27 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 4px;
+  gap: 8px;
   width: 100%;
 }
 
-.other_name {
-  margin-left: 5px;
+.name_container {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.name {
+  margin-right: 5px;
   font-size: 12px;
 }
 
-.mine_name {
-  margin-right: 5px;
-  font-size: 12px;
+.none_name {
+  display: none;
+}
+
+.profile_img {
+  border-radius: 50%;
 }
 
 .other_chat {

--- a/src/components/chat/chatting/Chatting.tsx
+++ b/src/components/chat/chatting/Chatting.tsx
@@ -1,11 +1,17 @@
+'use client';
+
 import React, { useEffect, useState } from 'react';
 import styles from './Chatting.module.scss';
 import { ScaleLoader } from 'react-spinners';
+import Image from 'next/image';
+import { getCookie } from '@/shared/utils/cookies';
+import { profile } from 'console';
 
 interface Props {
   type: 'other' | 'mine' | 'recording' | 'exit';
   name: string;
   message: string;
+  profileImg: string;
   questionIsLoading: boolean;
   recordingBox: boolean;
   onRecAudio: () => void;
@@ -20,6 +26,7 @@ const Chatting = ({
   type,
   name,
   message,
+  profileImg,
   recordingBox,
   handleToExitChat,
   onChangeIsAnswering,
@@ -64,7 +71,18 @@ const Chatting = ({
 
   return (
     <div className={type === 'other' ? styles.other_container : styles.mine_container}>
-      <p className={type === 'other' ? styles.other_name : styles.mine_name}>{name}</p>
+      <div className={styles.name_container}>
+        <Image
+          src={profileImg}
+          width={30}
+          height={40}
+          alt="profile_img"
+          className={styles.profile_img}
+          objectFit="cover"
+        />
+        <p className={type === 'other' ? styles.name : styles.none_name}>{name}</p>
+      </div>
+
       <div
         className={`
   ${type === 'other' ? styles.other_chat : styles.mine_chat}

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -1,0 +1,2 @@
+export const INTERVIER_PROFILE_IMG =
+  'https://dmmhn-next-js.vercel.app/_next/image?url=%2F_next%2Fstatic%2Fmedia%2FLogo.d92bc1f6.png&w=256&q=75';

--- a/src/models/chat/useHandleChat.ts
+++ b/src/models/chat/useHandleChat.ts
@@ -2,12 +2,14 @@ import { useCallback, useEffect, useState } from 'react';
 import { useSTT } from '../audio/useSTT';
 import { QuestionResponse } from '@/shared/types/question';
 import { useHandleQuestion } from '../question/useHandleQuestion';
-import { useHandleInterview } from '../simulation/useHandleInterview';
+import { getCookie } from '@/shared/utils/cookies';
+import { INTERVIER_PROFILE_IMG } from '@/constants/chat';
 
 interface ChatInfo {
   type: 'other' | 'mine' | 'recording' | 'exit';
   name: string;
   message: string;
+  profileImg: string;
 }
 
 /**
@@ -39,7 +41,12 @@ export const useHandleChat = ({
   const [isAnswering, setIsAnswering] = useState(false);
   const [recordingBox, setRecordingBox] = useState(false);
   const [chatInfoList, setChatInfoList] = useState<ChatInfo[]>([
-    { type: 'other', name: '면접관', message: '안녕하세요. 5초 후에 면접을 시작하겠습니다.' },
+    {
+      type: 'other',
+      name: '면접관',
+      message: '안녕하세요. 5초 후에 면접을 시작하겠습니다.',
+      profileImg: INTERVIER_PROFILE_IMG,
+    },
   ]);
   /**
    * 답변 중 상태를 변경합니다.
@@ -70,8 +77,8 @@ export const useHandleChat = ({
    * @param {string} chatInfo.message - 채팅 메시지 내용입니다.
    * @returns {void}
    */
-  const handleAddChatInfoList = useCallback(({ type, name, message }: ChatInfo) => {
-    setChatInfoList(prev => [...prev, { type, name, message }]);
+  const handleAddChatInfoList = useCallback(({ type, name, message, profileImg }: ChatInfo) => {
+    setChatInfoList(prev => [...prev, { type, name, message, profileImg }]);
   }, []);
 
   /**
@@ -79,7 +86,8 @@ export const useHandleChat = ({
    * @returns {void}
    */
   const addRecordingBox = useCallback(() => {
-    setChatInfoList(prev => [...prev, { type: 'recording', name: '나', message: '' }]);
+    const profileImg = getCookie('profileImg');
+    setChatInfoList(prev => [...prev, { type: 'recording', name: '나', message: '', profileImg }]);
   }, []);
 
   /**
@@ -101,7 +109,10 @@ export const useHandleChat = ({
       question: string;
     }) => {
       setTimeout(() => {
-        setChatInfoList(prev => [...prev, { type: 'other', name: '면접관', message: question }]);
+        setChatInfoList(prev => [
+          ...prev,
+          { type: 'other', name: '면접관', message: question, profileImg: INTERVIER_PROFILE_IMG },
+        ]);
       }, interviewerTimer);
 
       setTimeout(() => {
@@ -136,16 +147,19 @@ export const useHandleChat = ({
         type: 'other',
         name: '면접관',
         message: '면접이 종료되었습니다.',
+        profileImg: INTERVIER_PROFILE_IMG,
       });
       handleAddChatInfoList({
         type: 'other',
         name: '면접관',
         message: '결과를 확인해보실래요?',
+        profileImg: INTERVIER_PROFILE_IMG,
       });
       handleAddChatInfoList({
         type: 'exit',
         name: '나',
         message: '결과 확인하기',
+        profileImg: INTERVIER_PROFILE_IMG,
       });
     }
   };

--- a/src/widgets/chat/Chat.module.scss
+++ b/src/widgets/chat/Chat.module.scss
@@ -12,7 +12,7 @@
   display: flex;
   flex-grow: 1;
   flex-direction: column;
-  gap: 12px;
+  gap: 20px;
   overflow-y: auto;
   -ms-overflow-style: none;
   scrollbar-width: none;

--- a/src/widgets/chat/Chat.tsx
+++ b/src/widgets/chat/Chat.tsx
@@ -7,6 +7,7 @@ import ChattingList from '@/component_list/chattingList/ChattingList';
 import { useSTT } from '@/models/audio/useSTT';
 import { useHandleChat } from '@/models/chat/useHandleChat';
 import { QuestionResponse } from '@/shared/types/question';
+import { INTERVIER_PROFILE_IMG } from '@/constants/chat';
 
 interface Props {
   questionList: QuestionResponse[];
@@ -62,6 +63,7 @@ const Chat = ({ questionList, handleInterviewStatus, handleChangeInterviewChatRe
         type: 'other',
         name: '면접관',
         message: questionList[0].question,
+        profileImg: INTERVIER_PROFILE_IMG,
       });
     }, 5000);
 


### PR DESCRIPTION
## 어떤 기능인가요?

chat name을 단순 이름에서 profileImg와 이름으로 변경

## 작업 상세 내용

- [x] chat name을 단순 이름에서 profileImg와 이름으로 변경


## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

<img width="334" alt="스크린샷 2024-10-19 오후 12 17 26" src="https://github.com/user-attachments/assets/41851df9-b9d0-4eff-8724-1490b62e2465">