### PR TITLE
style: interview 페이지의 interviewing step border-radius 통일

### DIFF
--- a/src/widgets/interview/Interviewing/Interviewing.module.scss
+++ b/src/widgets/interview/Interviewing/Interviewing.module.scss
@@ -14,7 +14,7 @@
 .recoding_display {
   width: 100%;
   height: 100%;
-  border-radius: 28px;
+  border-radius: 12px;
   transform: scaleX(-1);
   object-fit: fill;
 }


### PR DESCRIPTION
## 어떤 기능인가요?

interview 페이지의 interviewing step border-radius 통일
- Chat 컴포넌트와 화면 녹화 Display 컴포넌트의 border-radius 12px로 통일

## 작업 상세 내용

- [x] 화면 녹화 display 컴포넌트의 border-radius 12px로 변경


## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

<img width="1436" alt="스크린샷 2024-10-19 오후 4 27 08" src="https://github.com/user-attachments/assets/63e8bdf7-2232-457c-8c19-2e4bde50d4b6">