### PR TITLE
refactor: queryString으로 관리하던 선택한 stack 리스트를 useState를 이용한 상태값 관리로 변경

### DIFF
--- a/src/app/interview/InterviewContainer.tsx
+++ b/src/app/interview/InterviewContainer.tsx
@@ -16,6 +16,7 @@ interface Props {
 const Simulation = ({ stacks, accessToken }: Props) => {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [selectedStacks, setSelectedStacks] = useState<string[]>([]);
   const [status, setStatus] = useState<InterviewStatus>('stacks');
   const [interviewChatResult, setInterviewChatResult] = useState<
     {
@@ -23,6 +24,19 @@ const Simulation = ({ stacks, accessToken }: Props) => {
       answer: string;
     }[]
   >([]);
+
+  const handleSelectStack = (stack: string) => {
+    setSelectedStacks(prev => {
+      if (prev.includes(stack)) {
+        return prev.filter(item => item !== stack);
+      }
+      if (prev.length >= 3) {
+        alert('기술 스택은 최대 3개까지 선택 가능합니다!');
+        return prev;
+      }
+      return [...prev, stack];
+    });
+  };
 
   const handleChangeInterviewChatResult = (
     interviewChatResult: { question: string; answer: string }[],
@@ -39,10 +53,18 @@ const Simulation = ({ stacks, accessToken }: Props) => {
 
   return (
     <main className={styles.container}>
-      {status === 'stacks' && <Stacks stacks={stacks} onChangeStatus={setStatus} />}
+      {status === 'stacks' && (
+        <Stacks
+          stacks={stacks}
+          selectedStacks={selectedStacks}
+          onChangeStatus={setStatus}
+          handleSelectStack={handleSelectStack}
+        />
+      )}
       {status === 'ready' && <Ready onChangeStatus={setStatus} />}
       {status === 'interviewing' && (
         <Interviewing
+          selectedStacks={selectedStacks}
           handleInterviewStatus={setStatus}
           handleChangeInterviewChatResult={handleChangeInterviewChatResult}
         />

--- a/src/models/simulation/useHandleInterview.ts
+++ b/src/models/simulation/useHandleInterview.ts
@@ -6,14 +6,13 @@ import { getQuestionListApi } from '@/queries/question/getQuestionListApi';
 import { useSearchParams } from 'next/navigation';
 
 export const useHandleInterview = () => {
-  const searchParams = useSearchParams();
-  const stacksId = searchParams.get('stacks');
   const [questionList, setQuestionList] = useState<QuestionResponse[]>([]);
 
-  const handleLoadQuestionList = useCallback(async () => {
-    const questionList = await getQuestionListApi(stacksId || '');
+  const handleLoadQuestionList = useCallback(async (stackIds: string[]) => {
+    const stackIdsString = stackIds.join(',');
+    const questionList = await getQuestionListApi(stackIdsString || '');
     setQuestionList(questionList);
-  }, [stacksId]);
+  }, []);
 
   return {
     questionList,

--- a/src/models/simulation/video.ts
+++ b/src/models/simulation/video.ts
@@ -21,6 +21,7 @@ export const useVideoHandler = (videoRef: React.RefObject<HTMLVideoElement>) => 
         videoRef.current.srcObject = mediaStream;
       }
     } catch (err) {
+      console.log('err', err);
       alert('카메라 정보를 가져오지 못했습니다. 권한 설정을 확인해주세요.');
     }
   }, [videoRef, setStream]);

--- a/src/widgets/interview/Interviewing/index.tsx
+++ b/src/widgets/interview/Interviewing/index.tsx
@@ -5,21 +5,26 @@ import styles from './Interviewing.module.scss';
 import Chat from '@/widgets/chat/Chat';
 
 interface Props {
+  selectedStacks: string[];
   handleInterviewStatus: (status: 'stacks' | 'ready' | 'interviewing' | 'end') => void;
   handleChangeInterviewChatResult: (
     interviewChatResult: { question: string; answer: string }[],
   ) => void;
 }
 
-export const Interviewing = ({ handleInterviewStatus, handleChangeInterviewChatResult }: Props) => {
+export const Interviewing = ({
+  selectedStacks,
+  handleInterviewStatus,
+  handleChangeInterviewChatResult,
+}: Props) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   useVideoHandler(videoRef);
 
   const { questionList, handleLoadQuestionList } = useHandleInterview();
 
   useEffect(() => {
-    handleLoadQuestionList();
-  }, [handleLoadQuestionList]);
+    handleLoadQuestionList(selectedStacks);
+  }, [selectedStacks, handleLoadQuestionList]);
 
   return (
     <div className={styles.layout}>

--- a/src/widgets/interview/Stacks/index.tsx
+++ b/src/widgets/interview/Stacks/index.tsx
@@ -10,45 +10,14 @@ import PrimaryBtn from '@/shared/components/Button/PrimaryBtn/PrimaryBtn';
 export type stack_type = '공통' | 'FE' | 'BE';
 
 interface Props {
-  onChangeStatus: (status: InterviewStatus) => void;
   stacks: Stack[];
+  selectedStacks: string[];
+  handleSelectStack: (stack: string) => void;
+  onChangeStatus: (status: InterviewStatus) => void;
 }
 
-export const Stacks = ({ onChangeStatus, stacks }: Props) => {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const [selectedStacks, setSelectedStacks] = useState<string[]>([]);
-
-  const createQueryString = useCallback(
-    (name: string, value: string) => {
-      const params = new URLSearchParams(searchParams.toString());
-      params.set(name, value);
-
-      return params.toString();
-    },
-    [searchParams],
-  );
-
-  const handleClickSelectStack = (stack: string) => {
-    setSelectedStacks(prev => {
-      if (prev.includes(stack)) {
-        return prev.filter(item => item !== stack);
-      }
-      if (prev.length >= 3) {
-        alert('기술 스택은 최대 3개까지 선택 가능합니다!');
-        return prev;
-      }
-      return [...prev, stack];
-    });
-  };
-
+export const Stacks = ({ stacks, selectedStacks, onChangeStatus, handleSelectStack }: Props) => {
   const applySelectedStacks = () => {
-    if (!selectedStacks.length) {
-      return;
-    }
-    const queryString = createQueryString('stacks', selectedStacks.join(','));
-    router.push(`${pathname}?${queryString}`);
     onChangeStatus('ready');
   };
 
@@ -64,7 +33,7 @@ export const Stacks = ({ onChangeStatus, stacks }: Props) => {
             <button
               type="button"
               name={type}
-              onClick={() => handleClickSelectStack(String(questionTypeId))}
+              onClick={() => handleSelectStack(String(questionTypeId))}
               className={
                 selectedStacks.includes(String(questionTypeId))
                   ? styles.selected_stack_name_btn


### PR DESCRIPTION
## 어떤 기능인가요?
페이지의 URL이 변경되기 전에 사용자가 stack 리스트를 이용해서 질문을 가져올 경우 URL 변경 전이기 때문에 에러 발생


## 작업 상세 내용

- [x] 선택한 stack 리스트를 queryString으로 변환하는 함수제거
- [x] 유저가 선택한 stack리스트를 관리하는 useState 추가