### PR TITLE
fix: interview 페이지의 Stacks Step 반응형 UI에서 Stack의 윗부분 그림자가 짤리는 현상 fix

### DIFF
--- a/src/widgets/interview/Stacks/Stacks.module.scss
+++ b/src/widgets/interview/Stacks/Stacks.module.scss
@@ -142,6 +142,7 @@
 
   .stack_name_wrapper {
     overflow-y: auto;
+    padding: 10px;
   }
 
   .next_btn_wrapper {


### PR DESCRIPTION
## 어떤 기능인가요?

interview 페이지의 Stacks Step 반응형 UI에서 Stack의 윗부분 그림자가 짤리는 현상 fix

## 작업 상세 내용

- [x] stack_name_wrapper에 padding 적용


## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

<img width="874" alt="스크린샷 2024-10-19 오후 11 31 53" src="https://github.com/user-attachments/assets/b4c1a05c-7d96-4529-b405-5c23356d7a21">