### PR TITLE
style: interview 페이지의 Ready Step 반응형 UI 구현

### DIFF
--- a/src/app/interview/page.module.scss
+++ b/src/app/interview/page.module.scss
@@ -8,3 +8,9 @@
   width: 100%;
   padding: 100px 200px;
 }
+
+@media (max-width: 1230px) {
+  .wrap {
+    padding: 100px 60px;
+  }
+}

--- a/src/shared/components/Button/PrimaryBtn/PrimaryBtn.module.scss
+++ b/src/shared/components/Button/PrimaryBtn/PrimaryBtn.module.scss
@@ -1,4 +1,5 @@
 .layout {
+  width: 100%;
   border-radius: 11px;
   border: 3px solid #058841;
   background: #fff;
@@ -30,7 +31,7 @@
   }
 }
 
-@media (max-width: 1230px) {
+@media (max-width: 1020px) {
   .layout {
     font-size: 28px;
   }

--- a/src/widgets/interview/Ready/Ready.module.scss
+++ b/src/widgets/interview/Ready/Ready.module.scss
@@ -61,6 +61,11 @@
   }
 }
 
+.btn_wrapper {
+  min-width: 350px;
+  min-height: 95px;
+}
+
 .stt_text_container {
   width: 100%;
   height: 100%;
@@ -75,4 +80,48 @@
 .btn_container {
   display: flex;
   justify-content: space-between;
+}
+
+@media (max-width: 1020px) {
+  .content_layout {
+    display: block;
+  }
+
+  .description {
+    text-align: center;
+
+    h1 {
+      font-size: 28px;
+      word-break: keep-all;
+    }
+
+    p {
+      word-break: keep-all;
+    }
+  }
+
+  .video_wrap {
+    display: none;
+
+    video {
+      display: none;
+    }
+
+    .recording {
+      display: none;
+    }
+  }
+
+  .stt_text_container {
+    display: none;
+  }
+
+  .btn_container {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .btn_wrapper {
+    width: 100%;
+  }
 }

--- a/src/widgets/interview/Ready/index.tsx
+++ b/src/widgets/interview/Ready/index.tsx
@@ -60,13 +60,17 @@ export const Ready = ({ transcript, handleResetCurrentScript, onChangeStatus }: 
         </div>
       </div>
       <div className={styles.btn_container}>
-        <PrimaryBtn text="이전으로" onClick={() => onChangeStatus('stacks')} />
-        <PrimaryBtn
-          text="시작"
-          onClick={() => {
-            onChangeStatus('interviewing');
-          }}
-        />
+        <div className={styles.btn_wrapper}>
+          <PrimaryBtn text="이전으로" onClick={() => onChangeStatus('stacks')} />
+        </div>
+        <div className={styles.btn_wrapper}>
+          <PrimaryBtn
+            text="시작"
+            onClick={() => {
+              onChangeStatus('interviewing');
+            }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/widgets/interview/Stacks/Stacks.module.scss
+++ b/src/widgets/interview/Stacks/Stacks.module.scss
@@ -125,7 +125,7 @@
   font-weight: 600;
 }
 
-@media (max-width: 1230px) {
+@media (max-width: 1020px) {
   .stack_header {
     margin-top: -20px;
     text-align: center;


### PR DESCRIPTION
## 어떤 기능인가요?

interview 페이지의 Ready Step 반응형 UI 구현


## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

<img width="1004" alt="스크린샷 2024-10-19 오후 11 59 55" src="https://github.com/user-attachments/assets/2a8de2f8-d119-4eaf-89a0-4b92e6146137">