### PR TITLE
feat: 소개페이지와 메인 서비스 페이지 인증시점 분리작업

### DIFF
--- a/src/components/auth/LoginModal/LoginModal.tsx
+++ b/src/components/auth/LoginModal/LoginModal.tsx
@@ -19,7 +19,7 @@ const LoginModal = () => {
         <ModalBody className={styles.content}>
           <Link
             className={styles.kakao_wrap}
-            href={`https://kauth.kakao.com/oauth/authorize?client_id=${process.env.KAKAO_CLIENT_ID}&redirect_uri=https://dmmhn-next-js.vercel.app/kakao/redirect&response_type=code`}
+            href={`https://kauth.kakao.com/oauth/authorize?client_id=${process.env.KAKAO_CLIENT_ID}&redirect_uri=${process.env.KAKAO_REDIRECT_URI}&response_type=code`}
           >
             <Image fill src="/kakao_login_medium_wide.png" alt="kakao_btn" />
           </Link>


### PR DESCRIPTION
- 로그인 모달에 카카오 리다이렉트uri를 환경변수로 변경해주었습니다.
- 미들웨어 코드를 정리하고 첫 진입 페이지와 로그인시 기본 페이지의 명확한 분리를 하였습니다.
