### PR TITLE
style: 인터뷰 피드백 파트 스타일 개선

### DIFF
--- a/src/components/feedback/FeedbackCard.tsx
+++ b/src/components/feedback/FeedbackCard.tsx
@@ -17,9 +17,10 @@ import {
 interface Props {
   heading: string;
   body?: string;
+  cardType: 'good' | 'bad' | 'totalFeedback';
 }
 
-export default function FeedbackCard({ heading, body }: Props) {
+export default function FeedbackCard({ heading, body, cardType }: Props) {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
@@ -28,9 +29,10 @@ export default function FeedbackCard({ heading, body }: Props) {
         width="100%"
         minHeight="100%"
         height="100%"
-        boxShadow="md"
+        boxShadow="lg"
         borderRadius="xl"
         overflow="hidden"
+        cursor="pointer"
         onClick={onOpen}
         transition="all 0.3s ease"
         _hover={{
@@ -38,32 +40,48 @@ export default function FeedbackCard({ heading, body }: Props) {
           boxShadow: 'xl',
         }}
       >
-        <CardHeader padding="0 5px 5px">
+        <CardHeader padding="10px 10px 2.5px 10px">
           <Heading
-            bgColor="green.600"
+            bgColor={
+              cardType === 'totalFeedback'
+                ? 'green.600'
+                : cardType === 'good'
+                ? 'blue.300'
+                : cardType === 'bad'
+                ? 'red.300'
+                : ''
+            }
             color="green.50"
             width="100%"
             padding="15px"
             borderRadius="xl"
-            borderBottomRadius="none"
+            borderBottomRadius="sm"
             size="lg"
           >
             {heading}
           </Heading>
         </CardHeader>
-        <CardBody padding="0 5px 5px">
+        <CardBody padding="2.5px 10px 10px 10px" overflow="hidden">
           <Text
-            // height="100%"
-            minHeight="100%"
             width="100%"
-            bgColor="green.100"
-            padding="15px"
+            height="100%"
+            bgColor={
+              cardType === 'totalFeedback'
+                ? 'green.100'
+                : cardType === 'good'
+                ? 'blue.100'
+                : cardType === 'bad'
+                ? 'red.100'
+                : ''
+            }
+            padding="5px 15px"
             borderRadius="xl"
-            borderTopRadius="none"
+            borderTopRadius="sm"
             fontSize="xl"
             fontWeight="600"
             color="green.900"
             lineHeight="1.8"
+            overflow="hidden"
             noOfLines={7}
           >
             {body}

--- a/src/widgets/interview/Feedback/index.tsx
+++ b/src/widgets/interview/Feedback/index.tsx
@@ -66,23 +66,55 @@ export const Feedback = ({ interviewResult, accessToken }: Props) => {
   const isLastPage = currentIndex === feedbacks.length;
 
   return (
-    <Flex direction="column" justify="center" align="center" boxSize="100%" gap="40px">
+    <Flex direction="column" justify="center" align="center" boxSize="100%" gap="30px">
       {/* 현재 피드백 받을 문제 */}
-      <Heading textAlign="left" width="100%">
-        {isLastPage
-          ? '마지막으로 요약을 제공해 드립니다.'
-          : `${interviewResult[currentIndex].question}`}
-      </Heading>
+      <Flex width="100%" padding="10px" boxShadow="lg" borderRadius="xl" align="center">
+        {!isLastPage && (
+          <Flex
+            justify="center"
+            align="center"
+            padding="10px"
+            bgColor="green.600"
+            color="green.50"
+            borderRadius="xl"
+            fontWeight="600"
+            fontSize="28px"
+            width="70px"
+          >
+            Q{currentIndex + 1}
+          </Flex>
+        )}
+        <Heading
+          textAlign="left"
+          width="100%"
+          fontSize="28px"
+          paddingY="10px"
+          marginLeft="10px"
+          color="green.900"
+        >
+          {isLastPage
+            ? '마지막으로 요약을 제공해 드립니다.'
+            : `${interviewResult[currentIndex].question}`}
+        </Heading>
+      </Flex>
 
       {/* 피드백 카드 */}
-      <Flex width="100%" align="center" height="345px" justify="center" gap="40px">
+      <Flex width="100%" align="center" height="345px" justify="center" gap="30px">
         {!isLastPage ? (
           <>
-            <FeedbackCard heading="잘하셨어요!" body={feedbacks[currentIndex].good} />
-            <FeedbackCard heading="아쉬운 점은..." body={feedbacks[currentIndex].bad} />
+            <FeedbackCard
+              heading="잘하셨어요!"
+              body={feedbacks[currentIndex].good}
+              cardType="good"
+            />
+            <FeedbackCard
+              heading="아쉬운 점은..."
+              body={feedbacks[currentIndex].bad}
+              cardType="bad"
+            />
           </>
         ) : (
-          <FeedbackCard heading="정리하자면..." body={totalFeedback} />
+          <FeedbackCard heading="정리하자면..." body={totalFeedback} cardType="totalFeedback" />
         )}
 
         {isLastPage && (
@@ -94,7 +126,7 @@ export const Feedback = ({ interviewResult, accessToken }: Props) => {
             justify="center"
             gap="30px"
           >
-            <Link as={NextLink} href="/" fontSize="28px" fontWeight="700">
+            <Link as={NextLink} href="/" fontSize="28px" fontWeight="700" color="green.900">
               처음으로
             </Link>
           </Flex>
@@ -107,7 +139,12 @@ export const Feedback = ({ interviewResult, accessToken }: Props) => {
           onClick={goToPrev}
           isDisabled={currentIndex === 0}
           colorScheme="green"
+          color="green.900"
+          fontSize="20px"
+          fontWeight="700"
           variant="ghost"
+          boxShadow="lg"
+          padding="10px 20px"
         >
           이전
         </Button>
@@ -121,7 +158,17 @@ export const Feedback = ({ interviewResult, accessToken }: Props) => {
             />
           ))}
         </HStack>
-        <Button onClick={goToNext} isDisabled={isLastPage} colorScheme="green" variant="ghost">
+        <Button
+          onClick={goToNext}
+          isDisabled={isLastPage}
+          colorScheme="green"
+          color="green.900"
+          fontSize="20px"
+          fontWeight="700"
+          variant="ghost"
+          boxShadow="lg"
+          padding="10px 20px"
+        >
           다음
         </Button>
       </Flex>


### PR DESCRIPTION
- 질문 번호를 추가하여 헤딩부분의 가독성을 향상시켰습니다.
- 카드의 배경을 good or bad or totalFeedback 타입으로 나누어 색상을 특정하였습니다.

<img width="1393" alt="image" src="https://github.com/user-attachments/assets/8a6990bd-f5e6-49af-b8ab-b7179731d5a6">

