### PR TITLE
feat: 면접 중 채팅 선택지 구현

### DIFF
--- a/src/component_list/chattingList/ChattingList.tsx
+++ b/src/component_list/chattingList/ChattingList.tsx
@@ -13,6 +13,7 @@ interface Props {
   onChangeRecordingBoxState: (state: boolean) => void;
   onChangeIsAnswering: (state: boolean) => void;
   handleToExitChat: () => void;
+  onDelayStopListening: (noAnswer?: string) => void;
 }
 
 const ChattingList = ({
@@ -21,6 +22,7 @@ const ChattingList = ({
   onChangeIsAnswering,
   onChangeRecordingBoxState,
   handleToExitChat,
+  onDelayStopListening,
 }: Props) => {
   return content.map((chatInfo, index) => (
     <div key={index} className={chatInfo.type === 'other' ? 'other' : 'mine'}>
@@ -34,6 +36,7 @@ const ChattingList = ({
         handleToExitChat={handleToExitChat}
         onChangeIsAnswering={onChangeIsAnswering}
         onChangeRecordingBoxState={onChangeRecordingBoxState}
+        onDelayStopListening={onDelayStopListening}
       />
     </div>
   ));

--- a/src/components/chat/ChattingItem/index.tsx
+++ b/src/components/chat/ChattingItem/index.tsx
@@ -6,6 +6,7 @@ import { ScaleLoader } from 'react-spinners';
 import SpeechRecognition from 'react-speech-recognition';
 import styles from './ChattingItem.module.scss';
 import { Button, Flex } from '@chakra-ui/react';
+import { useChatStore } from '@/shared/store/chatStore';
 
 interface Props {
   type: 'other' | 'mine' | 'recording' | 'exit';
@@ -34,6 +35,7 @@ export const ChattingItem = ({
   onDelayStopListening,
 }: Props) => {
   const [count, setCount] = useState(DEFAULT_READY_RECORDING_SECOND);
+  const { isSubmit } = useChatStore();
 
   useEffect(() => {
     let timer: NodeJS.Timeout;
@@ -95,6 +97,8 @@ export const ChattingItem = ({
               <Flex flexDirection="column" gap="5px">
                 <Button
                   onClick={() => onDelayStopListening()}
+                  isDisabled={isSubmit}
+                  isLoading={isSubmit}
                   backgroundColor="white"
                   borderRadius="2xl"
                   boxShadow="xl"
@@ -103,6 +107,8 @@ export const ChattingItem = ({
                 </Button>
                 <Button
                   onClick={() => onDelayStopListening('잘 모르겠습니다.')}
+                  isDisabled={isSubmit}
+                  isLoading={isSubmit}
                   backgroundColor="white"
                   borderRadius="2xl"
                   boxShadow="xl"

--- a/src/components/chat/ChattingItem/index.tsx
+++ b/src/components/chat/ChattingItem/index.tsx
@@ -2,11 +2,11 @@
 
 import React, { useEffect, useState } from 'react';
 import Image, { StaticImageData } from 'next/image';
-import { ScaleLoader } from 'react-spinners';
 import SpeechRecognition from 'react-speech-recognition';
-import styles from './ChattingItem.module.scss';
-import { Button, Flex } from '@chakra-ui/react';
+import { ScaleLoader } from 'react-spinners';
+import { Box, Button, Flex } from '@chakra-ui/react';
 import { useChatStore } from '@/shared/store/chatStore';
+import styles from './ChattingItem.module.scss';
 
 interface Props {
   type: 'other' | 'mine' | 'recording' | 'exit';
@@ -103,6 +103,7 @@ export const ChattingItem = ({
                   borderRadius="2xl"
                   boxShadow="xl"
                 >
+                  <Box width="10px" height="10px" rounded="full" bgColor="red.500" mr="5px" />
                   <ScaleLoader height={12} />
                 </Button>
                 <Button

--- a/src/components/chat/ChattingItem/index.tsx
+++ b/src/components/chat/ChattingItem/index.tsx
@@ -5,6 +5,7 @@ import Image, { StaticImageData } from 'next/image';
 import { ScaleLoader } from 'react-spinners';
 import SpeechRecognition from 'react-speech-recognition';
 import styles from './ChattingItem.module.scss';
+import { Button, Flex } from '@chakra-ui/react';
 
 interface Props {
   type: 'other' | 'mine' | 'recording' | 'exit';
@@ -16,6 +17,7 @@ interface Props {
   handleToExitChat: () => void;
   onChangeIsAnswering: (state: boolean) => void;
   onChangeRecordingBoxState: (state: boolean) => void;
+  onDelayStopListening: (noAnswer?: string) => void;
 }
 
 const DEFAULT_READY_RECORDING_SECOND = 3;
@@ -29,6 +31,7 @@ export const ChattingItem = ({
   handleToExitChat,
   onChangeIsAnswering,
   onChangeRecordingBoxState,
+  onDelayStopListening,
 }: Props) => {
   const [count, setCount] = useState(DEFAULT_READY_RECORDING_SECOND);
 
@@ -87,9 +90,30 @@ export const ChattingItem = ({
         onClick={() => type === 'exit' && handleToExitChat()}
       >
         {type === 'recording' ? (
-          <div>
-            {recordingBox ? <ScaleLoader height={12} /> : <p>{count}초 후 녹음이 시작됩니다</p>}
-          </div>
+          <Flex padding="2px">
+            {recordingBox ? (
+              <Flex flexDirection="column" gap="5px">
+                <Button
+                  onClick={() => onDelayStopListening()}
+                  backgroundColor="white"
+                  borderRadius="2xl"
+                  boxShadow="xl"
+                >
+                  <ScaleLoader height={12} />
+                </Button>
+                <Button
+                  onClick={() => onDelayStopListening('잘 모르겠습니다.')}
+                  backgroundColor="white"
+                  borderRadius="2xl"
+                  boxShadow="xl"
+                >
+                  잘 모르겠습니다.
+                </Button>
+              </Flex>
+            ) : (
+              <p>{count}초 후 녹음이 시작됩니다</p>
+            )}
+          </Flex>
         ) : (
           <p>{message}</p>
         )}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,10 @@
 import { NextRequest, NextResponse, userAgent } from 'next/server';
 import { apiInstance } from '@/shared/utils/axios';
-import { cookies } from 'next/headers';
-import { AxiosError } from 'axios';
 
 const PROTECTED_PATHS = ['/interview'];
 const ONE_DAY_PER_SEC = 24 * 60 * 60;
 
 export async function middleware(req: NextRequest) {
-  const cookieStore = cookies();
   const { pathname, searchParams } = req.nextUrl;
 
   const kakao_code = searchParams.get('code');
@@ -74,7 +71,6 @@ export async function middleware(req: NextRequest) {
   }
 
   if (PROTECTED_PATHS.includes(pathname) && accessToken) {
-    console.log('accessToken', accessToken);
     const res = await fetch(`${process.env.BASE_URL}/auth/login/check`, {
       method: 'POST',
       headers: {
@@ -82,7 +78,6 @@ export async function middleware(req: NextRequest) {
         Authorization: `Bearer ${accessToken}`,
       },
     });
-    console.log('res', res.ok);
     if (!res.ok) {
       let res;
       res = NextResponse.redirect(new URL('/', req.url));

--- a/src/shared/store/chatStore.ts
+++ b/src/shared/store/chatStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+
+type State = {
+  isSubmit: boolean;
+};
+
+type Action = {
+  setIsSubmit: (isSubmit: boolean) => void;
+};
+
+export const useChatStore = create<State & Action>(set => ({
+  isSubmit: false,
+  setIsSubmit: isSubmit => set({ isSubmit }),
+}));

--- a/src/widgets/chat/NormalChat/index.tsx
+++ b/src/widgets/chat/NormalChat/index.tsx
@@ -45,7 +45,6 @@ export const NormalChat = ({
     handleChangeIsAnswering,
     handleAddChatInfoList,
     addRecordingBox,
-
     submitAnswer,
   } = useHandleChat({
     questionList,
@@ -94,13 +93,18 @@ export const NormalChat = ({
     }
   }, [chatInfoList]);
 
-  const handleDelayStopListening = () => {
+  const handleDelayStopListening = (noAnswer?: string) => {
     setIsSubmit(true);
     setTimeout(() => {
       SpeechRecognition.stopListening();
 
       if (!sttText && listening) {
-        submitAnswer(sttText, chatInfoList, resetTranscript, handleChangeInterviewChatResult);
+        submitAnswer(
+          noAnswer ? '잘 모르겠습니다.' : sttText,
+          chatInfoList,
+          resetTranscript,
+          handleChangeInterviewChatResult,
+        );
         addProgressPercentage(20);
       }
       setIsSubmit(false);
@@ -133,6 +137,7 @@ export const NormalChat = ({
           handleToExitChat={handleToExitChat}
           onChangeIsAnswering={handleChangeIsAnswering}
           onChangeRecordingBoxState={handleChangeRecordingBox}
+          onDelayStopListening={handleDelayStopListening}
         />
       </div>
       <Flex borderTop="1px" borderColor="gray.400" w={'full'}>

--- a/src/widgets/chat/NormalChat/index.tsx
+++ b/src/widgets/chat/NormalChat/index.tsx
@@ -10,6 +10,7 @@ import { ProgressHeader } from '@/components/chat';
 import ChattingList from '@/component_list/chattingList/ChattingList';
 import INTERVIER_PROFILE_IMG from '../../../../public/Logo.png';
 import styles from './Chat.module.scss';
+import { useChatStore } from '@/shared/store/chatStore';
 
 interface Props {
   questionList: QuestionResponse[];
@@ -31,7 +32,7 @@ export const NormalChat = ({
   const [progress, setProgress] = useState(0);
 
   const { transcript: sttText, listening, resetTranscript } = useSpeechRecognition();
-  const [isSubmit, setIsSubmit] = useState(false);
+  const { setIsSubmit } = useChatStore();
 
   const addProgressPercentage = useCallback((percentage: number) => {
     setProgress(prev => prev + percentage);
@@ -125,6 +126,7 @@ export const NormalChat = ({
     resetTranscript,
     addProgressPercentage,
     handleChangeInterviewChatResult,
+    setIsSubmit,
   ]);
 
   return (
@@ -140,28 +142,6 @@ export const NormalChat = ({
           onDelayStopListening={handleDelayStopListening}
         />
       </div>
-      <Flex borderTop="1px" borderColor="gray.400" w={'full'}>
-        <Button
-          onClick={() => handleDelayStopListening()}
-          disabled={!isAnswering || isSubmit}
-          colorScheme="green"
-          variant="solid"
-          size="lg"
-          paddingY="10px"
-          borderRadius="lg"
-          borderTop="1px"
-          marginTop="8px"
-          w={'full'}
-        >
-          {isSubmit
-            ? '답변을 제출 중입니다...'
-            : chatInfoList[chatInfoList.length - 1].type === 'exit'
-            ? '면접이 끝났어요!'
-            : isAnswering
-            ? '답변을 마쳤어요!'
-            : '문제를 출제중입니다...'}
-        </Button>
-      </Flex>
     </div>
   );
 };


### PR DESCRIPTION
- 서버 실행 시 불필요하게 콘솔이 실행되어 미들웨어의 일부 코드를 삭제했습니다.
- 면접 중 답변 선택지 ui를 구현하고 녹음 중 상태를 더 잘 나타내도록 왼쪽에 뱃지를 추가해 주었습니다.
- 아래의 "잘 모르겠습니다."버튼을 클릭시 문자열로 그대로 들어가서 기존 아무 소리도 녹음되지 않은 상태의 답변과 일치하도록 하였습니다.
![스크린샷 2024-11-19 오후 3 46 14](https://github.com/user-attachments/assets/e2353451-c351-481a-aa44-b16be4c83e14)
- 기존 상위컴포넌트에서 관리하던 isSubmit 상태를 store를 통해 구독하는 형태로 바꾸어 prop drilling없이 버튼의 disabled와 loading상태를 제어하도록 하였습니다.
![스크린샷 2024-11-19 오후 3 47 43](https://github.com/user-attachments/assets/6168573d-3aeb-4a81-8449-bb657ef81564)
